### PR TITLE
discojuice : new renater feed used first (priority order)

### DIFF
--- a/Geo-SWITCHwayf/discojuice/update-discojuice.sh
+++ b/Geo-SWITCHwayf/discojuice/update-discojuice.sh
@@ -3,7 +3,7 @@
 MYDIR=$(dirname $(readlink -f $0))
 
 # Add urls to retrieve geolocation data
-GEOURLS="https://static.discojuice.org/feeds/edugain https://eduspot.renater.fr/discojuice/feed/renater"
+GEOURLS="https://eduspot.renater.fr/discojuice/feed/renater https://static.discojuice.org/feeds/edugain"
 
 cd $MYDIR
 
@@ -22,9 +22,11 @@ trap unlock INT TERM EXIT
 echo " > "$$ > $LOCK
 
 
+l=0
 for url in $GEOURLS
 do
-        wget -t 3 -T60 -q --no-check-certificate -O `basename $url`.json.tmp $url
+        wget -t 3 -T60 -q --no-check-certificate -O $l-`basename $url`.json.tmp $url
+	let "l++"
         sleep 5;
 done
 


### PR DESCRIPTION
Permet de donner un ordre de préférence au niveau du chargement des coordonnées GPS.
Ici le flux Renater est plus à jour (plus pertinent) que celui d'edugain donné sur static.discojuice.org.

Exemple : l'Insa de Toulouse est à Toulouse sur le flux renater, à Paris sur le flux edugain/discojuice.
Avec cette modification, INSA Toulouse est maintenant bien positionné dans notre WAYF ;-)