### PR TITLE
Fix PHP Notice when sp is not apache mod_shib (like saml proxy solution)

### DIFF
--- a/WAYF
+++ b/WAYF
@@ -481,19 +481,19 @@ if (
 		$discofeedDLCmd = 'php '.dirname(__FILE__).'/Geo-SWITCHwayf/discofeed/get-discofeed-from-string.php';
 		$JSONdir = dirname(__FILE__).'/Geo-SWITCHwayf/discofeed/feeds/';
 		global $SPShibUrl;
-		$splitedUrl;
+		$JSONfile;
 		if (is_array($_GET)){
 			foreach ($_GET as $key => $val){
 				preg_match('/^http(s):\/\/.*\/Shibboleth\.sso/', $val, $matches);
 				if (isset($matches[0]) && !empty($matches[0])){
 				 	$SPShibUrl = $matches[0];
 				 	$splitedUrl = preg_split('/\//', $SPShibUrl);
+					$JSONfile = $JSONdir.$splitedUrl[2].".json";
 				 	break;
 				 }
 			}
 		}
-		$JSONfile = $JSONdir.$splitedUrl[2].".json";
-		if (file_exists($JSONfile)){
+		if (isset($JSONfile) && file_exists($JSONfile)){
 			$string = file_get_contents($JSONfile);
 			$JSONtab = json_decode($string, true);
 			$discoFeed = array();


### PR DESCRIPTION
AH01071: Got error 'PHP message: PHP Notice:  Undefined variable: splitedUrl in /var/www/esup-wayf/WAYF on line 495PHP message: PHP Notice:  Trying to access array offset on value of type null in /var/www/esup-wayf/WAYF on line 495'