### PR TITLE
Correct Renater doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
-esup-wayf documentation
+# esup-wayf documentation
 
-## To install the software SWITCHwayf :
+## To install the software SWITCHwayf
 
 - Documentation SWITCH : Refer to the file README
-- Documentation Renater : https://services.renater.fr/federation/docs/installation/sp_decembre2012#installation_d_un_service_de_decouverte
-
+- Documentation Renater : <https://services.renater.fr/federation/documentation/guides-installation/sp3/chap06>
 
 ## Synopsis
 
 esup-wayf is based on the software SWITCHwayf v1.19.4. It is a custom theme that adds a map and locates the different identity providers on it. The user can select an IDP with the map or with a search field. It is possible to use Shibboleth's discofeed to filter the allowed IDP.
 ![esup-wayf](https://github.com/EsupPortail/esup-wayf/blob/master/images/wayf.png)
 
-
 ## Dependencies
 
-In order to run the WAYF and the CRON, you need the following softwares installed on your server : PHP5, Python, xmllint and imagick
+In order to run the WAYF and the CRON, you need the following softwares installed on your server: PHP5, Python, xmllint and imagick
 
 ## Installation
 
@@ -27,22 +25,22 @@ In order to run the WAYF and the CRON, you need the following softwares installe
 
 To enable discofeed on SP (Require Shibboleth >= 2.4)
 
-- In the service provider's shibboleth2.xml enable the discofeed (make sure that the location is "/DiscoFeed"). example : <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+- In the service provider's shibboleth2.xml enable the discofeed (make sure that the location is "/DiscoFeed"). example: `<Handler type="DiscoveryFeed" Location="/DiscoFeed"/>`
 - Restart Shibboleth.
 - Check that you can display the JSON file at "yourSP.univ.fr/Shibboleth.sso/DiscoFeed", the content of the SP's metadata file should appear.
 
-Important :
+**Important:**
 
 Make sure to enable writing permissions for the files IDProvider.metadata.php, SProvider.metadata.php, wayf_metadata.lock.
 
 Other softwares and library used
 
-	SWITCH WAYF v1.19.4
-	Leaflet v0.7.3
-	Open Street Map
-	Bootstrap v3.3.1
-	JQuery v1.10.2
-	Awesome Markers for Leaflet v1.0
-	Leaflet.markercluster
-	Renater Favicon-Fetcher
-	ImageMagick
+    SWITCH WAYF v1.19.4
+    Leaflet v0.7.3
+    Open Street Map
+    Bootstrap v3.3.1
+    JQuery v1.10.2
+    Awesome Markers for Leaflet v1.0
+    Leaflet.markercluster
+    Renater Favicon-Fetcher
+    ImageMagick


### PR DESCRIPTION
Bonjour, le lien indiqué comme doc dans le Readme renvoit une erreur 404 :
https://services.renater.fr/federation/docs/installation/sp_decembre2012#installation_d_un_service_de_decouverte

Je propose avec cette PR de le remplacer par celui-ci :
https://services.renater.fr/federation/documentation/guides-installation/sp3/chap06

(au passage, de la mise en forme mineure du markdown)