### PR TITLE
Sometime,  GeolocationHint can be an array and not directly a string - fix for php8

### DIFF
--- a/templates.php
+++ b/templates.php
@@ -321,6 +321,10 @@ function printOptionElement($IDProviders, $key, $selectedIDP){
 }
 
 function geoDataAttributes($GeolocationHint) {
+	 // Sometime, $GeolocationHint cans be an array and not directly a string
+	if(is_array($GeolocationHint)) {
+	   $GeolocationHint = $GeolocationHint[0];
+	}
 	if ($GeolocationHint &&
 	    preg_match("/^(-?[0-9.]+),(-?[0-9.]+)$/", $GeolocationHint, $match)){
 		return sprintf(' data-lat="%s" data-lon="%s"', $match[1], $match[2]);


### PR DESCRIPTION
Après un passage en php8, notre esup-wayf ne remontait plus d'établissements pour les SP proposés à EduGain.

Il se trouve que dans les SPs EduGain certains ont un GeolocationHint qui remonte en tant que tableau (à un élément) et pas directemet une chaine de caractères.

La fonction preg_match devait s'en accommoder en php7, ce n'est plus le cas en php8. 

Ce PR permet de contourrner ce problème